### PR TITLE
Add empty .nojekyll file before docs deploy

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -43,7 +43,11 @@ jobs:
         run: uv sync --all-extras --all-groups
 
       - name: Build docs
-        run: cd docs && rm -rf source/reference/api/_autosummary && uv run make html
+        run: |
+          cd docs
+          rm -rf source/reference/api/_autosummary
+          uv run make html
+          touch build/html/.nojekyll
 
       - name: Deploy to Github pages
         uses: JamesIves/github-pages-deploy-action@v4.6.8


### PR DESCRIPTION
# PR Type
Fix, documentation

# Short Description
 - creates an empty `.nojekyll` file in the output directory, which tells GitHub Pages not to process the files through Jekyll (https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll?t)
 - the github action doesn't have option to do this, leaving it to the devs to add a step (https://github.com/JamesIves/github-pages-deploy-action/issues/38?t)

# Tests Added
...
