### PR TITLE
Add fix to workflows to run unit, integration if either changes

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/code_checks.yml
       - .github/workflows/docs_build.yml
       - .github/workflows/docs_deploy.yml
+      - .github/workflows/unit_tests.yml
       - .github/workflows/integration_tests.yml
       - '**.py'
       - '**.ipynb'
@@ -24,6 +25,7 @@ on:
       - .github/workflows/code_checks.yml
       - .github/workflows/docs_build.yml
       - .github/workflows/docs_deploy.yml
+      - .github/workflows/unit_tests.yml
       - .github/workflows/integration_tests.yml
       - '**.py'
       - '**.ipynb'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/code_checks.yml
       - .github/workflows/docs_build.yml
       - .github/workflows/docs_deploy.yml
+      - .github/workflows/unit_tests.yml
       - .github/workflows/integration_tests.yml
       - '**.py'
       - '**.ipynb'
@@ -24,6 +25,7 @@ on:
       - .github/workflows/code_checks.yml
       - .github/workflows/docs_build.yml
       - .github/workflows/docs_deploy.yml
+      - .github/workflows/unit_tests.yml
       - .github/workflows/integration_tests.yml
       - '**.py'
       - '**.ipynb'


### PR DESCRIPTION
# PR Type
Fix

# Short Description
- Unit tests and integration tests need to both run to measure coverage.
- Hence if one of the workflow files change, the other workflow should also run to calculate coverage properly

# Tests Added
...
