### PR TITLE
Add uv-lock hook to ensure that the uv.lock file is always up to date

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,11 @@ repos:
     - id: check-yaml
     - id: check-toml
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.5.30
+    hooks:
+      - id: uv-lock
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.9.6'
     hooks:


### PR DESCRIPTION
# PR Type
CI

# Short Description

Add `uv-pre-commit` to ensure that the `uv.lock` file is always up to date.

# Tests Added
N/A