### PR TITLE
Add default dependency group config in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ uv sync --dev
 source .venv/bin/activate
 ```
 
+In order to exclude installation of packages from a specific group (e.g. docs),
+run:
+
+```bash
+uv sync --no-group docs
+```
+
 If you're coming from `poetry` then you'll notice that the virtual environment
 is actually stored in the project root folder and is by default named as `.venv`.
 The other important note is that while `poetry` uses a "flat" layout of the project,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ docs = [
     "ipython>=8.31.0",
 ]
 
+#Default dependency groups to be installed
+[tool.uv]
+default-groups = ["dev", "docs"]
+
 [tool.mypy]
 ignore_missing_imports = true
 install_types = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
     "ruff>=0.9.2",
 ]
 docs = [
-    "jinja2>=3.1.6",
+    "jinja2>=3.1.6", # Pinning version to address [GHSA-cpwx-vrp4-4pq7](https://github.com/advisories/GHSA-cpwx-vrp4-4pq7)
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.15",
     "mkdocstrings>=0.24.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ docs = [
     "ipython>=8.31.0",
 ]
 
-#Default dependency groups to be installed
+# Default dependency groups to be installed
 [tool.uv]
 default-groups = ["dev", "docs"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
     "ruff>=0.9.2",
 ]
 docs = [
-    "jinja2>=3.1.6", # Pinning version to address [GHSA-cpwx-vrp4-4pq7](https://github.com/advisories/GHSA-cpwx-vrp4-4pq7)
+    "jinja2>=3.1.6", # Pinning version to address vulnerability GHSA-cpwx-vrp4-4pq7
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.15",
     "mkdocstrings>=0.24.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "ruff>=0.9.2",
 ]
 docs = [
+    "jinja2>=3.1.6",
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.15",
     "mkdocstrings>=0.24.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -22,6 +23,7 @@ dev = [
 docs = [
     { name = "ipykernel" },
     { name = "ipython" },
+    { name = "jinja2" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings" },
@@ -46,6 +48,7 @@ dev = [
 docs = [
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "ipython", specifier = ">=8.31.0" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-material", specifier = ">=9.5.15" },
     { name = "mkdocstrings", specifier = ">=0.24.1" },
@@ -500,14 +503,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]


### PR DESCRIPTION
# PR Type
[Feature]

# Short Description
Currently, only `dev` dependency group is installed via `uv sync` command. `mkdocs` package in `docs` group isn't installed. 

```bash
$ uv sync
Using CPython 3.12.9 interpreter at: /opt/homebrew/opt/python@3.12/bin/python3.12
Creating virtual environment at: .venv
:

$ uv pip list | grep mkdocs
$
```

Changes in this PR:
1. Install both `doc` and `dev` dependency groups by default.
2. Add instructions in `README.md` to exclude specific groups.
3. Pin `jinja2` package version containing [vulnerability patch](https://github.com/advisories/GHSA-cpwx-vrp4-4pq7) to fix [code check failure](https://github.com/VectorInstitute/aieng-template-uv/actions/runs/14362213366).

# Tests Added
1. Installs packages in `docs` dependency group.
```bash
$ uv sync
Resolved 105 packages in 9ms
:

$ uv pip list | grep mkdocs
mkdocs                     1.6.1
mkdocs-autorefs            1.4.1
mkdocs-get-deps            0.2.0
mkdocs-material            9.6.11
mkdocs-material-extensions 1.3.1
mkdocstrings               0.29.1
mkdocstrings-python        1.16.10
```

2. Exclude a specific group from being installed.
```bash
$ uv sync --no-group docs
Resolved 105 packages in 6ms
:

$ uv pip list | grep mkdocs
$
```