### PR TITLE
Fix doctest path in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
     - id: doctest
       name: doctest
       entry: python3 -m doctest -o NORMALIZE_WHITESPACE
-      files: "^aieng_template/"
+      files: "^src/aieng_template_uv/"
       language: system
 
   - repo: local


### PR DESCRIPTION
# PR Type
Fix

# Short Description
The path for the `doctest` precommit hook is wrong. Fixing it here.

# Tests Added
NA
