### PR TITLE
Add write permissions in publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,9 +42,15 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          artifacts: "dist/*"
-          generateReleaseNotes: true
+  release_github:
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # To create a github release
+    steps:
+    - name: Create GitHub Release
+      id: create_release
+      uses: ncipollo/release-action@v1.21.0
+      with:
+        artifacts: "dist/*"
+        generateReleaseNotes: true


### PR DESCRIPTION
## Summary

Encountered the following error while using  current `publish.yml` workflow to publish a PyPI package:  `Error 404: Resource not accessible by Integration`. Identified root cause as missing `write` permissions for the GitHub repo in the workflow file. 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔒 Security fix

## Changes Made
- Create a separate job with `write` permissions for publishing the package to GitHub.

## Testing

<!-- Describe how you tested these changes -->
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Type checking passes (`uv run mypy <src_dir>`)
- [ ] Linting passes (`uv run ruff check src_dir/`)
- [x] Manual testing performed (describe below)

**Manual testing details:**
[Workflow](https://github.com/VectorInstitute/crisp-nam/actions/runs/24357950323) succeeded and PyPI package published after changes applied: https://pypi.org/project/crisp-nam

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

## Related Issues

<!-- Link any related issues using "Closes #123" or "Relates to #123" -->

## Deployment Notes

<!-- Any special deployment considerations or migration steps -->

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] No sensitive information (API keys, credentials) exposed
